### PR TITLE
allow support for nesting of log macros, similar to the NOP'd versions with do{}while(0)

### DIFF
--- a/lwlog.h
+++ b/lwlog.h
@@ -62,14 +62,14 @@
 /* safe readable version of errno */
 #define clean_errno() (errno == 0 ? "None" : strerror(errno))
 
-#define lwlog_emerg(M, ...)   fprintf(stderr, RED    "[EMERG]   " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno());
-#define lwlog_alert(M, ...)   fprintf(stderr, PURPLE "[ALERT]   " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno());
-#define lwlog_crit(M, ...)    fprintf(stderr, YELLOW "[CRIT]    " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno());
-#define lwlog_err(M, ...)     fprintf(stderr, BROWN  "[ERR]     " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno());
-#define lwlog_warning(M, ...) fprintf(stderr, BLUE   "[WARNING] " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno());
-#define lwlog_notice(M, ...)  fprintf(stderr, CYAN   "[NOTICE]  " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno());
-#define lwlog_info(M, ...)    fprintf(stderr, GREEN  "[INFO]    " "%s (%s:%d) " NONE M "\n", __func__, __FILE__, __LINE__, ##__VA_ARGS__);
-#define lwlog_debug(M, ...)   fprintf(stderr, GRAY   "[DEBUG]   " "%s (%s:%d) " NONE M "\n", __func__, __FILE__, __LINE__, ##__VA_ARGS__);
+#define lwlog_emerg(M, ...)   do { fprintf(stderr, RED    "[EMERG]   " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno()); } while(0)
+#define lwlog_alert(M, ...)   do { fprintf(stderr, PURPLE "[ALERT]   " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno()); } while(0)
+#define lwlog_crit(M, ...)    do { fprintf(stderr, YELLOW "[CRIT]    " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno()); } while(0)
+#define lwlog_err(M, ...)     do { fprintf(stderr, BROWN  "[ERR]     " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno()); } while(0)
+#define lwlog_warning(M, ...) do { fprintf(stderr, BLUE   "[WARNING] " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno()); } while(0)
+#define lwlog_notice(M, ...)  do { fprintf(stderr, CYAN   "[NOTICE]  " "%s (%s:%d) " NONE M YELLOW " errno: %s\n" NONE, __func__, __FILE__, __LINE__, ##__VA_ARGS__, clean_errno()); } while(0)
+#define lwlog_info(M, ...)    do { fprintf(stderr, GREEN  "[INFO]    " "%s (%s:%d) " NONE M "\n", __func__, __FILE__, __LINE__, ##__VA_ARGS__); } while(0)
+#define lwlog_debug(M, ...)   do { fprintf(stderr, GRAY   "[DEBUG]   " "%s (%s:%d) " NONE M "\n", __func__, __FILE__, __LINE__, ##__VA_ARGS__); } while(0)
 
 /* LOG_LEVEL controls */
 #if LOG_LEVEL < DEBUG


### PR DESCRIPTION
@Akagi201 Thanks for your nice header-only logging framework! I have been looking for something I can use for my C-based systems programming courses and your project is one of the few that met my requirement of *less is more*.

One minor issue I encountered is when trying to "nest" logging in various control structures. Interestingly, your macros that do a NOP when a log level is not enabled actually work fine. I used the same technique by surrounding the logging code with `do { your existing code } while(0)`.

As your code is designed to be header-only and bundled into projects, I already made this modification in my own code using it, but hopefully this will benefit other users who want a C-only solution for logging.